### PR TITLE
Make 2 functions to avoid unnecessary newlines

### DIFF
--- a/plugin/wsl-copy.vim
+++ b/plugin/wsl-copy.vim
@@ -19,12 +19,23 @@ function! WslSendToClipboard(type, ...) abort
 
     if a:0 " Invoked from visual mode, use gv command
         normal! gvy
+        call WslSendLastYankedToTmpFileAndSendToClip()
     elseif a:type ==# 'line'
         normal! '[V']y
+        echo "line!"
+        call WslSendLastYankedToTmpFileAndSendToClip()
     elseif a:type ==# 'char'
         normal! `[v`]y
+        call WslSendLastYankedToClip()
     endif
 
+    redraw!
+    echo 'wsl-copy: text yanked to clip.exe'
+    let &selection = l:sel_save
+    let @@ = l:reg_save
+endfunction
+
+function! WslSendLastYankedToTmpFileAndSendToClip() abort
     silent new /tmp/vimBuffer
     silent %d
     silent normal! "0P
@@ -33,9 +44,9 @@ function! WslSendToClipboard(type, ...) abort
     endif
     silent normal! ZZ
     silent ! cat /tmp/vimBuffer | clip.exe
-    redraw!
+endfunction
 
-    let &selection = l:sel_save
-    let @@ = l:reg_save
-
+" This function only works when there are no newlines:
+function! WslSendLastYankedToClip() abort
+    silent execute '! printf ' . shellescape(@@) . ' | clip.exe'
 endfunction


### PR DESCRIPTION
Make new function we can call when we are actioned as "char"
that is NOT linewise. In this function we avoid temp files
and use printf to pipe the text to clip.exe *without* unwanted
newline at the end.

Refactor old method into its own function, and call that when
we are actioned as "line", or from visual mode.

closes #1 
(well, Line-wise or visual-mode yanks will still have the excess newline,
but this fixes it were it's most important)