### PR TITLE
Remove default `wy` mapping, add `:Wsly` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,25 @@
 
 Enables yanking text from vim to windows clipboard on Windows Subsystem for Linux.
 
-Use the command `wy` from visual mode, or from normal mode with standard vim operands
-like `wyaw` to yank a word, `wy$` to yank until the end of the line, etc.
+Use `:Wsly` from visual mode to copy the current selection.
+
+Use `:Wsly` from normal mode to copy the last selection.
+
+Map to a key combination in order to use it with standard vim operands,
+like `*aw` to yank a word, `*$` to yank until the end of the line, etc
+(replacing * with the key combination you choose).
 
 ## Remapping
 
-If you would like to use another mapping just remap in vimrc:
+Map the plugin to the keys of your choice:
 
     nmap <silent> <new command> <Plug>WslCopy
     xmap <silent> <new command> <Plug>WslCopy
+
+For example:
+
+    nmap <silent> <leader>y <Plug>WslCopy
+    xmap <silent> <leader>y <Plug>WslCopy
 
 ## How to install
 

--- a/doc/wsl-copy.txt
+++ b/doc/wsl-copy.txt
@@ -1,5 +1,5 @@
 *wsl-copy.txt*	For Vim version 8.1	Last change: 2018 October 20
-*wsl-copy*
+*wsl-copy* *:Wsly*
 
 Copy text from Vim to Windows clipboard on WSL
 
@@ -10,17 +10,14 @@ License: MIT license
 
 COMMANDS
 
-The plugin adds the map-operator `wy`.
-It can be used together with any motion command, or from visual mode.
+The plugin adds the map-operator <Plug>WslCopy.
 
-If you would like to map to other keys, simply
+Remap to your preferred key combination:
 `nmap <silent> <new keys> <Plug>WslCopy` and `xmap <silent> <new keys> <Plug>WslCopy`
 
-Examples:
+Or execute as a command from visual mode with `:Wsly`
 
-	wyaw	wsl-copy a word
-	wy$	wsl-copy 'till the end of the line
-	vjjwy	wsl-copy selection (were selection is two lines down)
+After remapping it can be used together with any motion command, or from visual mode.
 
 
 RESTRICTIONS

--- a/plugin/wsl-copy.vim
+++ b/plugin/wsl-copy.vim
@@ -6,11 +6,7 @@
 
 nnoremap <silent> <Plug>WslCopy :set operatorfunc=WslSendToClipboard<cr>g@
 xnoremap <silent> <Plug>WslCopy :<C-U>call WslSendToClipboard(visualmode(),1)<cr>
-
-if !hasmapto('<Plug>WslCopy')
-    nmap <silent> wy <Plug>WslCopy
-    xmap <silent> wy <Plug>WslCopy
-endif
+command -range Wsly exe "normal gv \<Plug>WslCopy"
 
 function! WslSendToClipboard(type, ...) abort
     let l:sel_save = &selection


### PR DESCRIPTION
The `wy` mapping causes the `w` command to lag,
therefore its better to have the user choose a suitable combination.

Closes #4