### PR TITLE
Avoid error E174

### DIFF
--- a/plugin/wsl-copy.vim
+++ b/plugin/wsl-copy.vim
@@ -6,7 +6,7 @@
 
 nnoremap <silent> <Plug>WslCopy :set operatorfunc=WslSendToClipboard<cr>g@
 xnoremap <silent> <Plug>WslCopy :<C-U>call WslSendToClipboard(visualmode(),1)<cr>
-command -range Wsly exe "normal gv \<Plug>WslCopy"
+command! -range Wsly exe "normal gv \<Plug>WslCopy"
 
 function! WslSendToClipboard(type, ...) abort
     let l:sel_save = &selection


### PR DESCRIPTION
using `command!` to avoid 'E174: Command already exists: add ! to replace it'